### PR TITLE
Replace wrong sdformat11 package by sdformat12

### DIFF
--- a/debian/buster/debian/control
+++ b/debian/buster/debian/control
@@ -213,7 +213,7 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          libignition-math6-dev,
          libignition-plugin-dev (>= 1.1.0),
          libbullet-dev,
-         libsdformat11-dev,
+         libsdformat12-dev,
          libignition-physics5-bullet (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same

--- a/focal/debian/control
+++ b/focal/debian/control
@@ -215,7 +215,7 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          libignition-math6-eigen3-dev,
          libignition-plugin-dev,
          libbullet-dev,
-         libsdformat11-dev,
+         libsdformat12-dev,
          libignition-physics5-bullet (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -213,7 +213,7 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          libignition-math6-dev,
          libignition-plugin-dev (>= 1.1.0),
          libbullet-dev,
-         libsdformat11-dev,
+         libsdformat12-dev,
          libignition-physics5-bullet (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same


### PR DESCRIPTION
Some sdformat11 package ended up being used as dep in `libignition-physics5-bullet-dev` instead of the sdformat12. We need to release a new version to get the problem fixed.