### PR TITLE
Fix install paths after ign->gz migration

### DIFF
--- a/focal/debian/control
+++ b/focal/debian/control
@@ -38,10 +38,10 @@ Depends: libignition-cmake2-dev (>= 2.1.0),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Development files
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Core component, development files
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Core component, development files
 
 Package: libignition-physics5-sdf-dev
 Architecture: any
@@ -53,10 +53,10 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - SDF Dev files
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  SDF component, development files
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ SDF component, development files
 
 Package: libignition-physics5-mesh-dev
 Architecture: any
@@ -68,10 +68,10 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Mesh Dev files
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Mesh component, development files
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Mesh component, development files
 
 Package: libignition-physics5-heightmap-dev
 Architecture: any
@@ -83,10 +83,10 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Heightmap Dev files
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Heightmap component, development files
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Heightmap component, development files
 
 Package: libignition-physics5
 Architecture: any
@@ -95,10 +95,10 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Shared library
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Main shared library
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications
+ .
+ Main shared library
 
 Package: libignition-physics5-dartsim-dev
 Architecture: any
@@ -126,10 +126,10 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Development files
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Dartsim component, development files
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Dartsim component, development files
 
 Package: libignition-physics5-dartsim
 Architecture: any
@@ -138,10 +138,10 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Dartsim library
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  DARTSim component shared library
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ DARTSim component shared library
 
 Package: libignition-physics5-tpe-dev
 Architecture: any
@@ -158,10 +158,10 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Development files
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  TPE plugin component, development files
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ TPE plugin component, development files
 
 Package: libignition-physics5-tpe
 Architecture: any
@@ -170,10 +170,10 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - TPE library
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  TPE plugin component shared library
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ TPE plugin component shared library
 
 Package: libignition-physics5-tpelib-dev
 Architecture: any
@@ -186,10 +186,10 @@ Depends: libignition-cmake2-dev (>= 2.1.0),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Development files
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  TPE library component, development files
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ TPE library component, development files
 
 Package: libignition-physics5-tpelib
 Architecture: any
@@ -198,10 +198,10 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - TPE library
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  TPE library component shared library
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ TPE library component shared library
 
 Package: libignition-physics5-bullet-dev
 Architecture: any
@@ -220,10 +220,10 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Development files
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Bullet component, development files
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Bullet component, development files
 
 Package: libignition-physics5-bullet
 Architecture: any
@@ -232,10 +232,10 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Bullet engine
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Bullet component shared library
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Bullet component shared library
 
 Package: libignition-physics5-dev
 Architecture: any
@@ -251,14 +251,14 @@ Depends: libignition-physics5-core-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Metapackage
-  Gazebo Physics is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Metapackage, all development files
+ Gazebo Physics is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Metapackage, all development files
 
 Package: libgz-physics5-core-dev
 Depends: libignition-physics5-core-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -266,7 +266,7 @@ Description: transitional package
 
 Package: libgz-physics5-sdf-dev
 Depends: libignition-physics5-sdf-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -274,7 +274,7 @@ Description: transitional package
 
 Package: libgz-physics5-mesh-dev
 Depends: libignition-physics5-mesh-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -282,7 +282,7 @@ Description: transitional package
 
 Package: libgz-physics5-heightmap-dev
 Depends: libignition-physics5-heightmap-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -290,7 +290,7 @@ Description: transitional package
 
 Package: libgz-physics5
 Depends: libignition-physics5 (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -298,7 +298,7 @@ Description: transitional package
 
 Package: libgz-physics5-dartsim-dev
 Depends: libignition-physics5-dartsim-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -306,7 +306,7 @@ Description: transitional package
 
 Package: libgz-physics5-dartsim
 Depends: libignition-physics5-dartsim (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -314,7 +314,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpe-dev
 Depends: libignition-physics5-tpe-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -322,7 +322,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpe
 Depends: libignition-physics5-tpe (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -330,7 +330,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpelib-dev
 Depends: libignition-physics5-tpelib-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -338,7 +338,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpelib
 Depends: libignition-physics5-tpelib (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -346,7 +346,7 @@ Description: transitional package
 
 Package: libgz-physics5-bullet-dev
 Depends: libignition-physics5-bullet-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -354,7 +354,7 @@ Description: transitional package
 
 Package: libgz-physics5-bullet
 Depends: libignition-physics5-bullet (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -362,7 +362,7 @@ Description: transitional package
 
 Package: libgz-physics5-dev
 Depends: libignition-physics5-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -270,7 +270,7 @@ Description: Gazebo Physics classes and functions for robot apps - Metapackage
 
 Package: libgz-physics5-core-dev
 Depends: libignition-physics5-core-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -278,7 +278,7 @@ Description: transitional package
 
 Package: libgz-physics5-sdf-dev
 Depends: libignition-physics5-sdf-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -286,7 +286,7 @@ Description: transitional package
 
 Package: libgz-physics5-mesh-dev
 Depends: libignition-physics5-mesh-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -294,7 +294,7 @@ Description: transitional package
 
 Package: libgz-physics5-heightmap-dev
 Depends: libignition-physics5-heightmap-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -302,7 +302,7 @@ Description: transitional package
 
 Package: libgz-physics5
 Depends: libignition-physics5 (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -310,7 +310,7 @@ Description: transitional package
 
 Package: libgz-physics5-dartsim-dev
 Depends: libignition-physics5-dartsim-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -318,7 +318,7 @@ Description: transitional package
 
 Package: libgz-physics5-dartsim
 Depends: libignition-physics5-dartsim (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -326,7 +326,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpe-dev
 Depends: libignition-physics5-tpe-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -334,7 +334,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpe
 Depends: libignition-physics5-tpe (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -342,7 +342,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpelib-dev
 Depends: libignition-physics5-tpelib-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -350,7 +350,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpelib
 Depends: libignition-physics5-tpelib (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -358,7 +358,7 @@ Description: transitional package
 
 Package: libgz-physics5-bullet-dev
 Depends: libignition-physics5-bullet-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -366,7 +366,7 @@ Description: transitional package
 
 Package: libgz-physics5-bullet
 Depends: libignition-physics5-bullet (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -374,7 +374,7 @@ Description: transitional package
 
 Package: libgz-physics5-dev
 Depends: libignition-physics5-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -255,7 +255,7 @@ Description: Gazebo Physics classes and functions for robot apps - Metapackage
 
 Package: libgz-physics5-core-dev
 Depends: libignition-physics5-core-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -263,7 +263,7 @@ Description: transitional package
 
 Package: libgz-physics5-sdf-dev
 Depends: libignition-physics5-sdf-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -271,7 +271,7 @@ Description: transitional package
 
 Package: libgz-physics5-mesh-dev
 Depends: libignition-physics5-mesh-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -279,7 +279,7 @@ Description: transitional package
 
 Package: libgz-physics5-heightmap-dev
 Depends: libignition-physics5-heightmap-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -287,7 +287,7 @@ Description: transitional package
 
 Package: libgz-physics5
 Depends: libignition-physics5 (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -295,7 +295,7 @@ Description: transitional package
 
 Package: libgz-physics5-dartsim-dev
 Depends: libignition-physics5-dartsim-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -303,7 +303,7 @@ Description: transitional package
 
 Package: libgz-physics5-dartsim
 Depends: libignition-physics5-dartsim (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -311,7 +311,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpe-dev
 Depends: libignition-physics5-tpe-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -319,7 +319,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpe
 Depends: libignition-physics5-tpe (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -327,7 +327,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpelib-dev
 Depends: libignition-physics5-tpelib-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -335,7 +335,7 @@ Description: transitional package
 
 Package: libgz-physics5-tpelib
 Depends: libignition-physics5-tpelib (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -343,7 +343,7 @@ Description: transitional package
 
 Package: libgz-physics5-bullet-dev
 Depends: libignition-physics5-bullet-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -351,7 +351,7 @@ Description: transitional package
 
 Package: libgz-physics5-bullet
 Depends: libignition-physics5-bullet (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package
@@ -359,7 +359,7 @@ Description: transitional package
 
 Package: libgz-physics5-dev
 Depends: libignition-physics5-dev (= ${binary:Version}), ${misc:Depends}
-Architecture: all
+Architecture: any
 Priority: optional
 Section: oldlibs
 Description: transitional package

--- a/ubuntu/debian/libignition-physics-bullet-dev.install
+++ b/ubuntu/debian/libignition-physics-bullet-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/physics*/ignition/physics/bullet*/*
-usr/lib/*/cmake/ignition-physics[0-99]-bullet*/*
-usr/lib/*/libignition-physics[0-99]-bullet*.so
-usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-bullet*.so
-usr/lib/*/pkgconfig/ignition-physics[0-99]-bullet*.pc
+usr/include/*/physics*/*/physics/bullet*/*
+usr/lib/*/cmake/*-physics[0-99]-bullet*/*
+usr/lib/*/lib*-physics[0-99]-bullet*.so
+usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-bullet*.so
+usr/lib/*/pkgconfig/*-physics[0-99]-bullet*.pc

--- a/ubuntu/debian/libignition-physics-bullet.install
+++ b/ubuntu/debian/libignition-physics-bullet.install
@@ -1,2 +1,2 @@
-usr/lib/*/libignition-physics[0-99]-bullet*.so.*
-usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-bullet*.so.*
+usr/lib/*/lib*-physics[0-99]-bullet*.so.*
+usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-bullet*.so.*

--- a/ubuntu/debian/libignition-physics-core-dev.install
+++ b/ubuntu/debian/libignition-physics-core-dev.install
@@ -1,6 +1,6 @@
-usr/include/ignition/physics[0-99]/ignition/physics.hh
-usr/include/ignition/physics[0-99]/ignition/physics/*.hh
-usr/include/ignition/physics[0-99]/ignition/physics/detail/*.hh
-usr/lib/*/libignition-physics[0-99].so
-usr/lib/*/pkgconfig/ignition-physics[0-99].pc
-usr/lib/*/cmake/ignition-physics[0-99]/ignition-physics*
+usr/include/*/physics[0-99]/*/physics.hh
+usr/include/*/physics[0-99]/*/physics/*.hh
+usr/include/*/physics[0-99]/*/physics/detail/*.hh
+usr/lib/*/lib*-physics[0-99].so
+usr/lib/*/pkgconfig/*-physics[0-99].pc
+usr/lib/*/cmake/*-physics[0-99]/*-physics*

--- a/ubuntu/debian/libignition-physics-dartsim-dev.install
+++ b/ubuntu/debian/libignition-physics-dartsim-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/physics*/ignition/physics/dartsim*/*
-usr/lib/*/cmake/ignition-physics[0-99]-dartsim*/*
-usr/lib/*/libignition-physics[0-99]-dartsim*.so
-usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-dartsim*.so
-usr/lib/*/pkgconfig/ignition-physics[0-99]-dartsim*.pc
+usr/include/*/physics*/*/physics/dartsim*/*
+usr/lib/*/cmake/*-physics[0-99]-dartsim*/*
+usr/lib/*/lib*-physics[0-99]-dartsim*.so
+usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-dartsim*.so
+usr/lib/*/pkgconfig/*-physics[0-99]-dartsim*.pc

--- a/ubuntu/debian/libignition-physics-dartsim.install
+++ b/ubuntu/debian/libignition-physics-dartsim.install
@@ -1,2 +1,2 @@
-usr/lib/*/libignition-physics[0-99]-dartsim*.so.*
-usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-dartsim*.so.*
+usr/lib/*/lib*-physics[0-99]-dartsim*.so.*
+usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-dartsim*.so.*

--- a/ubuntu/debian/libignition-physics-dev.install
+++ b/ubuntu/debian/libignition-physics-dev.install
@@ -1,1 +1,1 @@
-usr/lib/*/cmake/ignition-physics[0-99]-all/ignition-physics[0-99]-all*
+usr/lib/*/cmake/*-physics[0-99]-all/*-physics[0-99]-all*

--- a/ubuntu/debian/libignition-physics-heightmap-dev.install
+++ b/ubuntu/debian/libignition-physics-heightmap-dev.install
@@ -1,3 +1,3 @@
-usr/include/ignition/physics*/ignition/physics/heightmap/*
-usr/lib/*/cmake/ignition-physics[0-99]-heightmap/*
-usr/lib/*/pkgconfig/ignition-physics[0-99]-heightmap.pc
+usr/include/*/physics*/*/physics/heightmap/*
+usr/lib/*/cmake/*-physics[0-99]-heightmap/*
+usr/lib/*/pkgconfig/*-physics[0-99]-heightmap.pc

--- a/ubuntu/debian/libignition-physics-mesh-dev.install
+++ b/ubuntu/debian/libignition-physics-mesh-dev.install
@@ -1,3 +1,3 @@
-usr/include/ignition/physics*/ignition/physics/mesh/*
-usr/lib/*/cmake/ignition-physics[0-99]-mesh/*
-usr/lib/*/pkgconfig/ignition-physics[0-99]-mesh.pc
+usr/include/*/physics*/*/physics/mesh/*
+usr/lib/*/cmake/*-physics[0-99]-mesh/*
+usr/lib/*/pkgconfig/*-physics[0-99]-mesh.pc

--- a/ubuntu/debian/libignition-physics-sdf-dev.install
+++ b/ubuntu/debian/libignition-physics-sdf-dev.install
@@ -1,3 +1,3 @@
-usr/include/ignition/physics*/ignition/physics/sdf/*
-usr/lib/*/cmake/ignition-physics[0-99]-sdf/*
-usr/lib/*/pkgconfig/ignition-physics[0-99]-sdf.pc
+usr/include/*/physics*/*/physics/sdf/*
+usr/lib/*/cmake/*-physics[0-99]-sdf/*
+usr/lib/*/pkgconfig/*-physics[0-99]-sdf.pc

--- a/ubuntu/debian/libignition-physics-tpe-dev.install
+++ b/ubuntu/debian/libignition-physics-tpe-dev.install
@@ -1,7 +1,7 @@
-usr/include/ignition/physics*/ignition/physics/tpe-plugin/*
-usr/lib/*/cmake/ignition-physics[0-99]-tpe-plugin/*
-usr/lib/*/cmake/ignition-physics[0-99]-tpe/*
-usr/lib/*/libignition-physics[0-99]-tpe-plugin.so
-usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-tpe-plugin.so
-usr/lib/*/pkgconfig/ignition-physics[0-99]-tpe-plugin.pc
-usr/lib/*/pkgconfig/ignition-physics[0-99]-tpe.pc
+usr/include/*/physics*/*/physics/tpe-plugin/*
+usr/lib/*/cmake/*-physics[0-99]-tpe-plugin/*
+usr/lib/*/cmake/*-physics[0-99]-tpe/*
+usr/lib/*/lib*-physics[0-99]-tpe-plugin.so
+usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-tpe-plugin.so
+usr/lib/*/pkgconfig/*-physics[0-99]-tpe-plugin.pc
+usr/lib/*/pkgconfig/*-physics[0-99]-tpe.pc

--- a/ubuntu/debian/libignition-physics-tpe.install
+++ b/ubuntu/debian/libignition-physics-tpe.install
@@ -1,2 +1,2 @@
-usr/lib/*/libignition-physics[0-99]-tpe-plugin*.so.*
-usr/lib/*/ign-physics-[0-99]/engine-plugins/libignition-physics*-tpe-plugin*.so.*
+usr/lib/*/lib*-physics[0-99]-tpe-plugin*.so.*
+usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-tpe-plugin*.so.*

--- a/ubuntu/debian/libignition-physics-tpelib-dev.install
+++ b/ubuntu/debian/libignition-physics-tpelib-dev.install
@@ -1,4 +1,4 @@
-usr/include/ignition/physics*/ignition/physics/tpelib/*
-usr/lib/*/cmake/ignition-physics[0-99]-tpelib/*
-usr/lib/*/libignition-physics[0-99]-tpelib.so
-usr/lib/*/pkgconfig/ignition-physics[0-99]-tpelib.pc
+usr/include/*/physics*/*/physics/tpelib/*
+usr/lib/*/cmake/*-physics[0-99]-tpelib/*
+usr/lib/*/lib*-physics[0-99]-tpelib.so
+usr/lib/*/pkgconfig/*-physics[0-99]-tpelib.pc

--- a/ubuntu/debian/libignition-physics-tpelib.install
+++ b/ubuntu/debian/libignition-physics-tpelib.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-physics[0-99]-tpelib*.so.*
+usr/lib/*/lib*-physics[0-99]-tpelib*.so.*

--- a/ubuntu/debian/libignition-physics.install
+++ b/ubuntu/debian/libignition-physics.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-physics[0-99].so.*
+usr/lib/*/lib*-physics[0-99].so.*


### PR DESCRIPTION
debbuilds failed (https://build.osrfoundation.org/job/ign-physics5-debbuilder/676) for ign-physics 5.3.0 and 5.3.1 due to errors in install paths.
The main fixes are the ones in the `*.install` files that account for the directory restructure in the ign->gz migration:

```
dh_install: warning: Cannot find (any matches for) "usr/include/ignition/physics[0-99]/ignition/physics/detail/*.hh" (tried in ., debian/tmp)

dh_install: warning: libignition-physics5-core-dev missing files: usr/include/ignition/physics[0-99]/ignition/physics/detail/*.hh
dh_install: warning: Cannot find (any matches for) "usr/include/ignition/physics*/ignition/physics/bullet*/*" (tried in ., debian/tmp)

dh_install: warning: libignition-physics5-bullet-dev missing files: usr/include/ignition/physics*/ignition/physics/bullet*/*
```
The fix is similar to https://github.com/gazebo-release/gz-sensors6-release/pull/15

The other changes fix lintian errors:

```
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5 -> libignition-physics5
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-bullet -> libignition-physics5-bullet
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-bullet-dev -> libignition-physics5-bullet-dev
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-core-dev -> libignition-physics5-core-dev
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-dartsim -> libignition-physics5-dartsim
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-dartsim-dev -> libignition-physics5-dartsim-dev
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-dev -> libignition-physics5-dev
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-heightmap-dev -> libignition-physics5-heightmap-dev
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-mesh-dev -> libignition-physics5-mesh-dev
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-sdf-dev -> libignition-physics5-sdf-dev
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-tpe -> libignition-physics5-tpe
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-tpe-dev -> libignition-physics5-tpe-dev
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-tpelib -> libignition-physics5-tpelib
E: ignition-physics5 source: not-binnmuable-all-depends-any libgz-physics5-tpelib-dev -> libignition-physics5-tpelib-dev
```